### PR TITLE
faster loading of illustration detail fragment during swipes

### DIFF
--- a/app/src/main/java/com/perol/asdpl/pixivez/fragments/PictureXFragment.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/fragments/PictureXFragment.kt
@@ -46,7 +46,6 @@ import com.perol.asdpl.pixivez.adapters.PictureXAdapter
 import com.perol.asdpl.pixivez.adapters.TagsAdapter
 import com.perol.asdpl.pixivez.databinding.FragmentPictureXBinding
 import com.perol.asdpl.pixivez.dialog.CommentDialog
-import com.perol.asdpl.pixivez.objects.LazyV4Fragment
 import com.perol.asdpl.pixivez.objects.Toasty
 import com.perol.asdpl.pixivez.services.GlideApp
 import com.perol.asdpl.pixivez.viewmodel.PictureXViewModel
@@ -64,11 +63,11 @@ private const val ARG_PARAM1 = "param1"
  * create an instance of this fragment.
  *
  */
-class PictureXFragment : LazyV4Fragment() {
+class PictureXFragment : Fragment() {
 
     private var param1: Long? = null
     lateinit var pictureXViewModel: PictureXViewModel
-    override fun loadData() {
+    fun loadData() {
 //        val item = activity?.intent?.extras
 //        val illust = item?.getParcelable<Illust>(param1.toString())
         pictureXViewModel.firstGet(param1!!, null)

--- a/app/src/main/java/com/perol/asdpl/pixivez/fragments/PictureXFragment.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/fragments/PictureXFragment.kt
@@ -205,6 +205,7 @@ class PictureXFragment : Fragment() {
 //              no more anko
             }
         })
+        loadData()
 
     }
 


### PR DESCRIPTION
On PictureXFragment, extending class Fragment instead of LazyV4Fragment, fragments are loaded during swipes instead of loading after swipe is complete.
In the original app, for me, the user experience is ruined a bit because when i swipe right, page is blank and takes a little bit of time to load. Extending fragment class loads the fragment so I can  see the illustration detail even when the image is not loaded.