### PR TITLE
Tag history shows tag name and translated name(if available)

### DIFF
--- a/app/src/main/java/com/perol/asdpl/pixivez/activity/SearchRActivityFragment.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/activity/SearchRActivityFragment.kt
@@ -57,7 +57,10 @@ class SearchRActivityFragment : Fragment() {
         recyclerview.layoutManager = LinearLayoutManager(activity)
         recyclerview.adapter = tagsTextAdapter
         tagsTextAdapter.setOnItemClickListener { adapter, view, position ->
-            tagsTextViewModel.addhistory(tags[position].name)
+            val s_tag = tags[position]
+            if (s_tag.translated_name.isNotEmpty())
+                tagsTextViewModel.addhistory(s_tag.name + "|" + s_tag.translated_name)
+            else tagsTextViewModel.addhistory(s_tag.name)
             val bundle = Bundle()
             bundle.putString("searchword", tags[position].name)
             val intent = Intent(activity!!, SearchResultActivity::class.java)

--- a/app/src/main/java/com/perol/asdpl/pixivez/fragments/TrendTagFragment.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/fragments/TrendTagFragment.kt
@@ -120,7 +120,12 @@ class TrendTagFragment : Fragment() {
 
     private fun upToPage(query: String) {
         val bundle = Bundle()
-        bundle.putString("searchword", query)
+        var nameQuery = query
+        if (query.contains('|')) {
+            val splits = query.split('|')
+            nameQuery = splits[0]
+        }
+        bundle.putString("searchword", nameQuery)
         val intent = Intent(activity!!, SearchResultActivity::class.java)
         intent.putExtras(bundle)
         startActivityForResult(intent, 775)


### PR DESCRIPTION
When user searches for a tag, those tags are saved so users can see their tag history. However, tag history only shows the tag name which are mostly in japanese and chinese and international users might not understand so need tag history that shows tag name + its translated name.

Currently, tags are saved as tag name | translated name and when users tap on it, it is split so only tag name is searched
This feature is also not available in pixiv app and it will benefit international users.