### PR TITLE
调整“设置”与“主题”页面部分首选项样式，修复部分UI细节问题

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -189,4 +189,11 @@ dependencies {
     androidTestImplementation 'androidx.test:core:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 
+    // Material Dialogs: https://github.com/afollestad/material-dialogs
+    implementation 'com.afollestad.material-dialogs:core:3.1.1'
+    implementation 'com.afollestad.material-dialogs:files:3.1.1'
+    implementation 'com.afollestad.material-dialogs:bottomsheets:3.1.1'
+    implementation 'com.afollestad.material-dialogs:lifecycle:3.1.1'
+
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0' // https://github.com/square/leakcanary
 }

--- a/app/src/main/java/com/perol/asdpl/pixivez/activity/LoginActivity.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/activity/LoginActivity.kt
@@ -96,11 +96,11 @@ class LoginActivity : RinkActivity() {
         ThemeUtil.themeInit(this)
         setContentView(R.layout.activity_login)
         val window = window
-        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
-        window.decorView.systemUiVisibility =
-            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-        window.statusBarColor = Color.TRANSPARENT
+//        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+//        window.decorView.systemUiVisibility =
+//            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS or WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+//        window.statusBarColor = Color.TRANSPARENT
 
         setSupportActionBar(toolbar)
         supportActionBar!!.setDisplayShowTitleEnabled(false)
@@ -309,9 +309,12 @@ class LoginActivity : RinkActivity() {
 //                            loginBtn.isEnabled = true // Avoid double logins.
 
                         Toast.makeText(applicationContext, "登录成功", Toast.LENGTH_LONG).show()
-                        val intent = Intent(this@LoginActivity, HelloMActivity::class.java)
+                        val intent = Intent(this@LoginActivity, HelloMActivity::class.java).apply {
+                            // 避免循环添加账号导致相同页面嵌套。或者在添加账号（登录）成功时回到账号列表页面而不是导航至新的主页
+                            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK // Or launchMode = "singleTop|singleTask"
+                        }
                         startActivity(intent)
-                        finish()
+//                        finish()
                     }
                 })
         }

--- a/app/src/main/java/com/perol/asdpl/pixivez/activity/ThemeActivity.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/activity/ThemeActivity.kt
@@ -24,20 +24,29 @@
 
 package com.perol.asdpl.pixivez.activity
 
-import android.app.Activity
+import android.content.SharedPreferences
+import android.content.res.Resources
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.MenuItem
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.LinearLayout
+import androidx.annotation.ColorRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
-import androidx.preference.DropDownPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
-import androidx.recyclerview.widget.LinearLayoutManager
-import com.chad.library.adapter.base.BaseQuickAdapter
+import com.afollestad.materialdialogs.LayoutMode
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.bottomsheets.BottomSheet
+import com.afollestad.materialdialogs.bottomsheets.GridItem
+import com.afollestad.materialdialogs.bottomsheets.gridItems
+import com.afollestad.materialdialogs.callbacks.onDismiss
+import com.afollestad.materialdialogs.lifecycle.lifecycleOwner
 import com.perol.asdpl.pixivez.R
-import com.perol.asdpl.pixivez.adapters.ColorData
-import com.perol.asdpl.pixivez.adapters.ColorfulAdapter
 import com.perol.asdpl.pixivez.objects.ThemeUtil
 import com.perol.asdpl.pixivez.services.PxEZApp
 import kotlinx.android.synthetic.main.activity_theme.*
@@ -46,14 +55,94 @@ class ThemeActivity : AppCompatActivity() {
     class ThemeFragment : PreferenceFragmentCompat() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             addPreferencesFromResource(R.xml.pre_theme)
-            findPreference<DropDownPreference>("dark_mode")!!.setOnPreferenceChangeListener { preference, newValue ->
+            findPreference<Preference>("dark_mode")!!.setOnPreferenceChangeListener { preference, newValue ->
                 AppCompatDelegate.setDefaultNightMode(newValue.toString().toInt())
                 PxEZApp.instance.setTheme(R.style.AppThemeBase_pink)
                 true
             }
+
+            val items = listOf(
+                BackgroundGridItem(R.color.colorPrimary, "Primary"),
+                BackgroundGridItem(R.color.md_blue_300, "Blue"),
+                BackgroundGridItem(R.color.pink, "Pink"),
+                BackgroundGridItem(R.color.miku, "Miku"),
+                BackgroundGridItem(R.color.md_purple_500, "Purple"),
+                BackgroundGridItem(R.color.md_cyan_300, "Cyan"),
+                BackgroundGridItem(R.color.md_green_300, "Green"),
+                BackgroundGridItem(R.color.md_indigo_300, "Indigo"),
+                BackgroundGridItem(R.color.md_red_500, "Red"),
+                BackgroundGridItem(R.color.now, "Pale green")
+            )
+
+            findPreference<Preference>("theme")?.apply {
+                summary =
+                    items[PreferenceManager.getDefaultSharedPreferences(requireContext()).getInt(
+                        "colorint",
+                        0
+                    )].title
+                onPreferenceClickListener =
+                    Preference.OnPreferenceClickListener {
+                        MaterialDialog(
+                            requireContext(),
+                            BottomSheet(LayoutMode.WRAP_CONTENT)
+                        ).show {
+                            var action: (() -> Unit)? = null
+
+                            title(R.string.title_change_theme)
+                            gridItems(items) { _, index, item ->
+                                it.summary = item.title
+                                PreferenceManager.getDefaultSharedPreferences(requireContext())
+                                    .apply {
+                                        putInt("colorint", index)
+                                    }
+
+                                action = {
+                                    PxEZApp.ActivityCollector.recreate()
+                                }
+                            }
+                            onDismiss {
+                                action?.invoke()
+                            }
+                            cornerRadius(16.0F)
+                            negativeButton(android.R.string.cancel)
+                            positiveButton(R.string.action_apply)
+                            lifecycleOwner(this@ThemeFragment)
+                        }
+                        true
+                    }
+            }
+        }
+
+        private inline fun SharedPreferences.apply(modifier: SharedPreferences.Editor.() -> Unit) {
+            edit().apply { modifier() }.run { apply() }
         }
     }
 
+    private class BackgroundGridItem(@ColorRes private val color: Int, override val title: String) :
+        GridItem {
+
+        override fun populateIcon(imageView: ImageView) {
+            imageView.apply {
+                setBackgroundColor(ContextCompat.getColor(imageView.context, color))
+                layoutParams = LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                ).apply {
+                    marginEnd = 4.dp
+                    marginStart = 4.dp
+                }
+            }
+        }
+
+        private val Int.dp: Int get() = toFloat().dp.toInt()
+
+        private val Float.dp: Float
+            get() = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                this,
+                Resources.getSystem().displayMetrics
+            )
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -62,28 +151,29 @@ class ThemeActivity : AppCompatActivity() {
         setSupportActionBar(toolbar)
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         supportFragmentManager.beginTransaction().replace(R.id.fragment_theme, ThemeFragment()).commit()
-        val list = arrayListOf(
-                ColorData(ContextCompat.getColor(this, R.color.colorPrimary), "Primary"),
-                ColorData(ContextCompat.getColor(this, R.color.md_blue_300), "Blue"),
-                ColorData(ContextCompat.getColor(this, R.color.pink), "Pink"),
-                ColorData(ContextCompat.getColor(this, R.color.miku), "Miku"),
-            ColorData(ContextCompat.getColor(this, R.color.md_purple_500), "Purple"),
-                ColorData(ContextCompat.getColor(this, R.color.md_cyan_300), "Cyan"),
-                ColorData(ContextCompat.getColor(this, R.color.md_green_300), "Green"),
-                ColorData(ContextCompat.getColor(this, R.color.md_indigo_300), "Indigo"),
-                ColorData(ContextCompat.getColor(this, R.color.md_red_500), "Red"),
-                ColorData(ContextCompat.getColor(this, R.color.now), "Pale green"))
-        recyclerview.apply {
-            layoutManager = LinearLayoutManager(this@ThemeActivity)
-            adapter = ColorfulAdapter(R.layout.view_colorfulitem, list).apply {
-                onItemClickListener = BaseQuickAdapter.OnItemClickListener { adapter, view, position ->
-                    PreferenceManager.getDefaultSharedPreferences(this@ThemeActivity).edit().putInt("colorint", position).apply()
-                    setResult(Activity.RESULT_OK)
-                    finish()
-                }
-            }
-            isNestedScrollingEnabled = false
-        }
+//        return
+//        val list = arrayListOf(
+//                ColorData(ContextCompat.getColor(this, R.color.colorPrimary), "Primary"),
+//                ColorData(ContextCompat.getColor(this, R.color.md_blue_300), "Blue"),
+//                ColorData(ContextCompat.getColor(this, R.color.pink), "Pink"),
+//                ColorData(ContextCompat.getColor(this, R.color.miku), "Miku"),
+//            ColorData(ContextCompat.getColor(this, R.color.md_purple_500), "Purple"),
+//                ColorData(ContextCompat.getColor(this, R.color.md_cyan_300), "Cyan"),
+//                ColorData(ContextCompat.getColor(this, R.color.md_green_300), "Green"),
+//                ColorData(ContextCompat.getColor(this, R.color.md_indigo_300), "Indigo"),
+//                ColorData(ContextCompat.getColor(this, R.color.md_red_500), "Red"),
+//                ColorData(ContextCompat.getColor(this, R.color.now), "Pale green"))
+//        recyclerview.apply {
+//            layoutManager = LinearLayoutManager(this@ThemeActivity)
+//            adapter = ColorfulAdapter(R.layout.view_colorfulitem, list).apply {
+//                onItemClickListener = BaseQuickAdapter.OnItemClickListener { adapter, view, position ->
+//                    PreferenceManager.getDefaultSharedPreferences(this@ThemeActivity).edit().putInt("colorint", position).apply()
+//                    setResult(Activity.RESULT_OK)
+//                    finish()
+//                }
+//            }
+//            isNestedScrollingEnabled = false
+//        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/com/perol/asdpl/pixivez/adapters/AccountChoiceAdapter.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/adapters/AccountChoiceAdapter.kt
@@ -24,8 +24,7 @@
 
 package com.perol.asdpl.pixivez.adapters
 
-import android.graphics.Color
-import android.graphics.LightingColorFilter
+import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.preference.PreferenceManager
 import com.bumptech.glide.Glide
@@ -46,14 +45,6 @@ class AccountChoiceAdapter(layoutResId: Int, data: List<UserEntity>) :
                 .setText(R.id.textView4, item.username)
                 .setText(R.id.textview_email, item.useremail)
         val delete = helper.getView<ImageView>(R.id.imageview_delete)
-        if (helper.layoutPosition == PreferenceManager.getDefaultSharedPreferences(mContext).getInt(
-                "usernum",
-                0
-            )
-        ) {
-            helper.setImageResource(R.id.imageview_delete, R.drawable.ic_check_black_24dp)
-        }
-        delete.colorFilter = LightingColorFilter(Color.BLACK, Color.BLACK)
         delete.setOnClickListener {
             runBlocking {
                 AppDataRepository.deleteUser(item)
@@ -61,5 +52,19 @@ class AccountChoiceAdapter(layoutResId: Int, data: List<UserEntity>) :
                 this@AccountChoiceAdapter.setNewData(data)
             }
         }
+        if (helper.layoutPosition == PreferenceManager.getDefaultSharedPreferences(mContext).getInt(
+                "usernum",
+                0
+            )
+        ) {
+            (delete.parent as ViewGroup).isClickable = false
+            delete.isClickable = false
+            helper.setImageResource(R.id.imageview_delete, R.drawable.ic_check_black_24dp)
+        } else {
+            (delete.parent as ViewGroup).isClickable = true
+            delete.isClickable = true
+            helper.setImageResource(R.id.imageview_delete, R.drawable.ic_close_black_24dp)
+        }
+//        delete.colorFilter = LightingColorFilter(Color.BLACK, Color.BLACK)
     }
 }

--- a/app/src/main/java/com/perol/asdpl/pixivez/fragments/ThanksFragment.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/fragments/ThanksFragment.kt
@@ -24,31 +24,127 @@
 
 package com.perol.asdpl.pixivez.fragments
 
+import android.content.Intent
+import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.os.Bundle
 import android.widget.ImageView
+import androidx.annotation.DrawableRes
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CircleCrop
+import com.bumptech.glide.request.RequestOptions
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.perol.asdpl.pixivez.BuildConfig
 import com.perol.asdpl.pixivez.R
 import com.perol.asdpl.pixivez.dialog.ThanksDialog
 
-
 class ThanksFragment : PreferenceFragmentCompat() {
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.pre_thanks)
         findPreference<PreferenceCategory>("huonaicai")?.isVisible = !BuildConfig.ISGOOGLEPLAY
+
+        findPreference<Preference>("xuemo")?.apply {
+            loadDrawableByUrl(
+                "https://avatars.githubusercontent.com/LuckXuemo",
+                R.drawable.xuemo,
+                onLoadCleared = { it?.let { icon = it } },
+                onResourceReady = { icon = it })
+            onPreferenceClickListener = Preference.OnPreferenceClickListener {
+                startActivityByUri("https://github.com/LuckXuemo")
+                true
+            }
+        }
+        findPreference<Preference>("hunterx9")?.apply {
+            loadDrawableByUrl(
+                "https://avatars.githubusercontent.com/hunterx9",
+                R.drawable.hunterx9,
+                onLoadCleared = { it?.let { icon = it } },
+                onResourceReady = { icon = it })
+            onPreferenceClickListener = Preference.OnPreferenceClickListener {
+                startActivityByUri("https://github.com/hunterx9")
+                true
+            }
+        }
+        findPreference<Preference>("Skimige")?.apply {
+            loadDrawableByUrl(
+                "https://avatars.githubusercontent.com/Skimige",
+                R.drawable.skimige,
+                onLoadCleared = { it?.let { icon = it } },
+                onResourceReady = { icon = it })
+            onPreferenceClickListener = Preference.OnPreferenceClickListener {
+                startActivityByUri("https://github.com/Skimige")
+                true
+            }
+        }
+
+//        listOf(
+//            mapOf(
+//                "Preference" to findPreference<Preference?>("xuemo"),
+//                "AvatarUrl" to "https://avatars.githubusercontent.com/LuckXuemo",
+//                "Placeholder" to R.drawable.xuemo,
+//                "GithubProfile" to "https://github.com/LuckXuemo"
+//            ),
+//            mapOf(
+//                "Preference" to findPreference<Preference?>("hunterx9"),
+//                "AvatarUrl" to "https://avatars.githubusercontent.com/hunterx9",
+//                "Placeholder" to R.drawable.hunterx9,
+//                "GithubProfile" to "https://github.com/hunterx9"
+//            ),
+//            mapOf(
+//                "Preference" to findPreference<Preference?>("Skimige"),
+//                "AvatarUrl" to "https://avatars.githubusercontent.com/Skimige",
+//                "Placeholder" to R.drawable.skimige,
+//                "GithubProfile" to "https://github.com/Skimige"
+//            )
+//        ).forEach {
+//            (it["Preference"] as Preference?)?.apply {
+//                loadDrawableByUrl(
+//                    it["AvatarUrl"] as String,
+//                    it["Placeholder"] as Int,
+//                    onLoadCleared = { d -> d?.let { icon = d } },
+//                    onResourceReady = { d -> icon = d })
+//                onPreferenceClickListener = Preference.OnPreferenceClickListener { _ ->
+//                    startActivityByUri(it["GithubProfile"] as String)
+//                    true
+//                }
+//            }
+//        }
     }
 
     override fun onPreferenceTreeClick(preference: Preference?): Boolean {
         when (preference?.key) {
-            "support" -> {
-
-            }
+            "support" -> startActivityByUri("https://play.google.com/store/apps/details?id=com.perol.asdpl.play.pixivez")
+            "pr" -> startActivityByUri("https://github.com/Notsfsssf/Pix-EzViewer/pulls")
             "thanks" -> {
                 val thanksDialog = ThanksDialog()
                 thanksDialog.show(childFragmentManager)
+
+//                MaterialDialog(requireContext()).show {
+//                    customView(R.layout.dialog_thanks, scrollable = true, horizontalPadding = false)
+//                    cornerRadius(2.0F)
+//                    lifecycleOwner(this@ThanksFragment)
+//                }.getCustomView().apply {
+//                    list.apply {
+//                        adapter = ThanksAdapter(R.layout.simple_list_item, ThanksDialog().array).apply {
+//                            setHeaderView(LayoutInflater.from(context).inflate(R.layout.dialog_thanks_header, null, false))
+//                        }
+//                        layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+//                    }
+//                }
+
+//                MaterialDialog(requireContext()).show {
+////                    title(text = "")
+//                    message(R.string.summary)
+//                    listItems(items = ThanksDialog().array)
+//                    cornerRadius(2.0F)
+//                    lifecycleOwner(this@ThanksFragment)
+//                }
             }
             "wepay" -> {
                 val view = activity!!.layoutInflater.inflate(R.layout.wepayimage, null)
@@ -61,5 +157,38 @@ class ThanksFragment : PreferenceFragmentCompat() {
 
         }
         return super.onPreferenceTreeClick(preference)
+    }
+
+    private fun startActivityByUri(uri: String) {
+        Intent(Intent.ACTION_VIEW).apply {
+            data = Uri.parse(uri)
+        }.also {
+            it.resolveActivity(requireContext().packageManager)?.run {
+                startActivity(it)
+            }
+        }
+    }
+
+    private fun loadDrawableByUrl(
+        url: String, @DrawableRes placeholder: Int,
+        onLoadCleared: (Drawable?) -> Unit,
+        onResourceReady: (Drawable) -> Unit
+    ) {
+        Glide.with(this@ThanksFragment)
+            .load(url)
+            .apply(RequestOptions.bitmapTransform(CircleCrop()))
+            .placeholder(placeholder)
+            .into(object : CustomTarget<Drawable>() {
+                override fun onLoadCleared(placeholder: Drawable?) {
+                    onLoadCleared(placeholder)
+                }
+
+                override fun onResourceReady(
+                    resource: Drawable,
+                    transition: Transition<in Drawable>?
+                ) {
+                    onResourceReady(resource)
+                }
+            })
     }
 }

--- a/app/src/main/java/com/perol/asdpl/pixivez/services/PxEZApp.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/services/PxEZApp.kt
@@ -29,7 +29,6 @@ import android.app.Application
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
-import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
 import androidx.work.WorkManager
@@ -37,7 +36,6 @@ import com.orhanobut.logger.AndroidLogAdapter
 import com.orhanobut.logger.Logger
 import com.perol.asdpl.pixivez.objects.CrashHandler
 import java.io.File
-
 
 class PxEZApp : Application() {
 
@@ -64,29 +62,29 @@ class PxEZApp : Application() {
 
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
             override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-                Log.v(TAG, "${activity.simpleName}: onActivityCreated.")
+                Logger.t(TAG).v("${activity.simpleName}: onActivityCreated")
 
                 ActivityCollector.collect(activity)
             }
 
             override fun onActivityStarted(activity: Activity) {
-                Log.v(TAG, "${activity.simpleName}: onActivityStarted.")
+                Logger.t(TAG).v("${activity.simpleName}: onActivityStarted")
             }
 
             override fun onActivityResumed(activity: Activity) {
-                Log.v(TAG, "${activity.simpleName}: onActivityResumed.")
+                Logger.t(TAG).v("${activity.simpleName}: onActivityResumed")
             }
 
             override fun onActivityPaused(activity: Activity) {
-                Log.v(TAG, "${activity.simpleName}: onActivityPaused.")
+                Logger.t(TAG).v("${activity.simpleName}: onActivityPaused")
             }
 
             override fun onActivityStopped(activity: Activity) {
-                Log.v(TAG, "${activity.simpleName}: onActivityStopped.")
+                Logger.t(TAG).v("${activity.simpleName}: onActivityStopped")
             }
 
             override fun onActivityDestroyed(activity: Activity) {
-                Log.v(TAG, "${activity.simpleName}: onActivityDestroyed.")
+                Logger.t(TAG).v("${activity.simpleName}: onActivityDestroyed")
 
                 ActivityCollector.discard(activity)
             }
@@ -103,20 +101,24 @@ class PxEZApp : Application() {
         @JvmStatic
         private val activityList = mutableListOf<Activity>()
 
+        @JvmStatic
         fun collect(activity: Activity) {
             activityList.add(activity)
         }
 
+        @JvmStatic
         fun discard(activity: Activity) {
             activityList.remove(activity)
         }
 
+        @JvmStatic
         fun recreate() {
             for (i in activityList.size - 1 downTo 0) {
                 activityList[i].recreate()
             }
         }
     }
+
     companion object {
         @JvmStatic
         var storepath = Environment.getExternalStorageDirectory().absolutePath + File.separator + "PxEz"

--- a/app/src/main/res/layout/activity_saucenao.xml
+++ b/app/src/main/res/layout/activity_saucenao.xml
@@ -28,6 +28,7 @@
                     android:layout_height="?attr/actionBarSize"
                     app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
                     app:theme="@style/MyToolbar"
+                    android:background="?attr/colorPrimary"
                     app:title="以图搜源"
                     app:titleTextColor="?android:attr/textColorPrimaryInverse" />
             </com.google.android.material.appbar.AppBarLayout>
@@ -36,19 +37,19 @@
                 android:id="@+id/cardView3"
                 android:layout_width="match_parent"
                 android:layout_height="90dp"
-                android:layout_margin="@dimen/dp_10"
+                android:layout_margin="8dp"
                 app:cardBackgroundColor="?attr/colorPrimary">
 
                 <ImageView
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_gravity="center"
-                    android:layout_marginStart="20dp"
+                    android:layout_marginStart="16dp"
 
-                    android:layout_marginTop="20dp"
-                    android:layout_marginEnd="20dp"
-                    android:layout_marginBottom="20dp"
-                    android:scaleType="fitStart"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="16dp"
+                    android:scaleType="fitCenter"
                     android:src="@drawable/banner" />
             </com.google.android.material.card.MaterialCardView>
 
@@ -56,7 +57,8 @@
                 android:layout_width="match_parent"
 
                 android:layout_height="wrap_content"
-                android:layout_margin="@dimen/dp_10"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
                 android:background="?attr/colorPrimary">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
@@ -94,7 +96,7 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="@dimen/dp_10"
+                android:layout_margin="8dp"
                 android:background="?attr/colorPrimary"
 
                 >
@@ -104,8 +106,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_gravity="center"
-                    android:layout_margin="@dimen/dp_10"
-                    android:scaleType="fitStart"
+                    android:layout_margin="0dp"
+                    android:scaleType="fitCenter"
                     android:src="@drawable/ai" />
             </com.google.android.material.card.MaterialCardView>
         </LinearLayout>

--- a/app/src/main/res/layout/app_bar_hello_m.xml
+++ b/app/src/main/res/layout/app_bar_hello_m.xml
@@ -16,10 +16,10 @@
             android:layout_height="wrap_content"
             app:elevation="0dp">
 
-            <com.google.android.material.appbar.CollapsingToolbarLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_scrollFlags="scroll|enterAlways">
+<!--            <com.google.android.material.appbar.CollapsingToolbarLayout-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                app:layout_scrollFlags="scroll|enterAlways">-->
 
                 <com.google.android.material.appbar.MaterialToolbar
                     android:id="@+id/toolbar"
@@ -28,6 +28,7 @@
                     android:background="?attr/colorPrimary"
                     android:minHeight="?attr/actionBarSize"
                     android:theme="@style/MyToolbar"
+                    app:layout_scrollFlags="scroll|snap|enterAlways"
                     app:contentInsetEndWithActions="0dp"
                     app:contentInsetStart="0.0dp"
                     app:contentInsetStartWithNavigation="0dp">
@@ -43,7 +44,7 @@
                         app:tabPaddingStart="20dp" />
 
                 </com.google.android.material.appbar.MaterialToolbar>
-            </com.google.android.material.appbar.CollapsingToolbarLayout>
+<!--            </com.google.android.material.appbar.CollapsingToolbarLayout>-->
 
 
         </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/dialog_thanks.xml
+++ b/app/src/main/res/layout/dialog_thanks.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-
 <androidx.recyclerview.widget.RecyclerView android:id="@+id/list"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingBottom="24dp"
+    android:paddingTop="24dp"
+    android:clipToPadding="false"
     xmlns:android="http://schemas.android.com/apk/res/android" />
-
-
-

--- a/app/src/main/res/layout/dialog_thanks_header.xml
+++ b/app/src/main/res/layout/dialog_thanks_header.xml
@@ -3,35 +3,37 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp">
 
-    android:layout_height="match_parent">
-
-    <com.google.android.material.card.MaterialCardView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:cardPreventCornerOverlap="true"
-        app:cardUseCompatPadding="true">
+<!--    <com.google.android.material.card.MaterialCardView-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        app:cardPreventCornerOverlap="true"-->
+<!--        app:cardUseCompatPadding="true">-->
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="8dp"
+
             android:text="@string/summary" />
-    </com.google.android.material.card.MaterialCardView>
+<!--    </com.google.android.material.card.MaterialCardView>-->
 
-    <com.google.android.material.card.MaterialCardView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:cardPreventCornerOverlap="true"
-        app:cardUseCompatPadding="true">
+<!--    <com.google.android.material.card.MaterialCardView-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        app:cardPreventCornerOverlap="true"-->
+<!--        app:cardUseCompatPadding="true">-->
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="8dp"
+            android:layout_marginBottom="16dp"
+            android:layout_marginTop="24dp"
             android:text="非常感谢你们的支持:"
             android:textColor="?attr/colorPrimary"
-            android:textSize="22sp" />
+            android:textSize="20sp" />
 
-    </com.google.android.material.card.MaterialCardView>
+<!--    </com.google.android.material.card.MaterialCardView>-->
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_hello_main.xml
+++ b/app/src/main/res/layout/fragment_hello_main.xml
@@ -17,6 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="top"
+            android:elevation="4dp"
             app:tabIndicatorFullWidth="true">
 
         </com.google.android.material.tabs.TabLayout>

--- a/app/src/main/res/layout/nav_header_hello_m.xml
+++ b/app/src/main/res/layout/nav_header_hello_m.xml
@@ -16,9 +16,9 @@
         android:id="@+id/imageView"
         android:layout_width="60dp"
         android:layout_height="60dp"
+        android:scaleType="centerCrop"
         android:transitionName="userimage"
         android:contentDescription="@string/nav_header_desc"
-        android:paddingTop="@dimen/nav_header_vertical_spacing"
         app:srcCompat="@mipmap/ic_launcherep" />
 
     <TextView

--- a/app/src/main/res/layout/simple_list_item.xml
+++ b/app/src/main/res/layout/simple_list_item.xml
@@ -1,23 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <com.google.android.material.card.MaterialCardView
-    android:layout_width="match_parent"
-    app:cardUseCompatPadding="true"
-    app:cardPreventCornerOverlap="true"
-    android:layout_height="wrap_content">
+<!--    <com.google.android.material.card.MaterialCardView-->
+<!--    android:layout_width="match_parent"-->
+<!--    app:cardUseCompatPadding="true"-->
+<!--    app:cardPreventCornerOverlap="true"-->
+<!--    android:layout_height="wrap_content">-->
     <TextView
-        android:text="1"
+        tools:text="1"
         android:id="@+id/name"
-        android:textSize="18sp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
+        android:textSize="16sp"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginTop="0dp"
+        android:layout_marginBottom="0dp"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-    </com.google.android.material.card.MaterialCardView>
+        android:gravity="center_vertical"
+        android:layout_height="48dp" />
+<!--    </com.google.android.material.card.MaterialCardView>-->
 </RelativeLayout>

--- a/app/src/main/res/layout/view_account_item.xml
+++ b/app/src/main/res/layout/view_account_item.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <ImageView
         android:id="@+id/imageView4"
-        android:layout_width="80dp"
-        android:layout_height="80dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -20,30 +21,31 @@
         android:id="@+id/textView4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginStart="16dp"
+        app:layout_constraintBottom_toTopOf="@id/textview_email"
+        app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintStart_toEndOf="@+id/imageView4"
-        app:layout_constraintTop_toTopOf="@+id/imageView4" />
+        app:layout_constraintTop_toTopOf="@+id/imageView4"
+        tools:text="Username" />
 
     <TextView
         android:id="@+id/textview_email"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        app:layout_constraintLeft_toRightOf="@id/imageView4"
-        app:layout_constraintStart_toEndOf="@+id/imageView4"
-        app:layout_constraintTop_toBottomOf="@+id/textView4" />
+        android:layout_marginTop="0dp"
+        app:layout_constraintBottom_toBottomOf="@id/imageView4"
+        app:layout_constraintStart_toStartOf="@id/textView4"
+        app:layout_constraintTop_toBottomOf="@+id/textView4"
+        tools:text="Email" />
 
     <ImageButton
         android:id="@+id/imageview_delete"
-        android:background="@color/transparent"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:tintMode="add"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="8dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:padding="4dp"
+        android:tint="?attr/colorControlNormal"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/view_colorfulitem.xml
+++ b/app/src/main/res/layout/view_colorfulitem.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground">
 
     <ImageView
-    android:layout_margin="@dimen/dp_4"
-    android:id="@+id/imagevew_colorful"
+        android:layout_margin="16dp"
+        android:id="@+id/imagevew_colorful"
         android:layout_alignParentStart="true"
         android:layout_width="40dp"
         android:layout_height="40dp" />
 
     <TextView
-        android:layout_marginStart="16dp"
+        android:layout_marginStart="0dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/name"
         android:layout_centerVertical="true"
         android:layout_toEndOf="@+id/imagevew_colorful"
-        android:text="1111111111111" />
+        tools:text="1111111111111" />
 </RelativeLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -194,6 +194,7 @@
     <string name="taziliao">information</string>
     <string name="internal">internal</string>
     <string name="language">language</string>
+    <string name="pref_language">Language</string>
     <string name="themecoloful">Theme Colorful</string>
     <string name="setting">Setting</string>
     <string name="savesuccess">saved!</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -194,6 +194,7 @@
     <string name="taziliao">ta的資料</string>
     <string name="internal">內置</string>
     <string name="language">語言</string>
+    <string name="pref_language">語言</string>
     <string name="themecoloful">主題樣式</string>
     <string name="setting">設定</string>
     <string name="savesuccess">儲存圖像成功!</string>
@@ -254,6 +255,7 @@
     <string name="download_progress">下載進度</string>
     <string name="join_download_queue">加入下載隊列</string>
     <string name="again_to_exit">再按壹次返回鍵退出</string>
+    <string name="dark_mode">深色主題</string>
     <string name="restart_now">立即重啟</string>
     <string name="account_management">賬號管理</string>
     <string name="auto_check_update">自動檢查更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,7 @@
     <string name="taziliao">ta的资料</string>
     <string name="internal">内置</string>
     <string name="language">语言</string>
+    <string name="pref_language">语言</string>
     <string name="themecoloful">主题样式</string>
     <string name="setting">设置</string>
     <string name="savesuccess">保存图片成功!</string>
@@ -270,7 +271,7 @@
     <string name="download_progress">下载进度</string>
     <string name="join_download_queue">加入下载队列</string>
     <string name="again_to_exit">再按一次返回键退出</string>
-    <string name="dark_mode">Dark Mode</string>
+    <string name="dark_mode">深色主题</string>
     <string name="restart_now">立即重启</string>
     <string name="account_management">账号管理</string>
     <string name="auto_check_update">自动检查更新</string>
@@ -283,4 +284,11 @@
     <string name="end_date">End Date</string>
     <string name="choice_date">Choice Date</string>
     <string name="summary">在刚接触JAVA的时候边学官方文档边做,摸索着完成了这个客户端,因为个人能力的问题,出过不少丢人的BUG,优化问题,在完善这个应用的过程中，我获得了很多的开发经验与比较深刻的教训，也得到了很多人的帮助和支持</string>
+    <string name="title_change_theme">更换主题</string>
+    <string name="title_save_path">保存路径</string>
+    <string name="title_change_icon">更换图标</string>
+    <string name="title_theme_color">主题颜色</string>
+    <string name="action_apply">应用</string>
+    <string name="action_select">选择</string>
+    <string name="action_change">更换</string>
 </resources>

--- a/app/src/main/res/xml/pre_theme.xml
+++ b/app/src/main/res/xml/pre_theme.xml
@@ -2,7 +2,7 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory app:title="DayNight">
-    <DropDownPreference
+        <ListPreference
         android:entryValues="@array/dark_mode_value"
         app:defaultValue="-1"
         app:entries="@array/dark_mode"
@@ -11,6 +11,11 @@
         app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
     <PreferenceCategory app:title="Color">
+
+        <Preference
+            app:key="theme"
+            app:summary="TODO"
+            app:title="@string/title_theme_color" />
 
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -67,21 +67,21 @@
         <Preference
             app:key="storepath1"
             app:title="@string/savepath" />
-        <DropDownPreference
+        <ListPreference
             android:entries="@array/format"
             android:entryValues="@array/format_value"
             app:defaultValue="0"
             app:key="saveformat"
             app:title="@string/saveformat"
             app:useSimpleSummaryProvider="true" />
-        <DropDownPreference
+        <ListPreference
             android:entries="@array/firstpage"
             android:entryValues="@array/firstpage_value"
             app:defaultValue="0"
             app:key="firstpage"
             app:title="@string/startpage"
             app:useSimpleSummaryProvider="true" />
-        <DropDownPreference
+        <ListPreference
             android:entryValues="@array/quality_value"
             app:defaultValue="0"
             app:entries="@array/quality"
@@ -93,7 +93,7 @@
             android:entryValues="@array/language_values"
             app:defaultValue="0"
             app:key="language"
-            app:title="Language" />
+            app:title="@string/pref_language" />
     </PreferenceCategory>
 
 


### PR DESCRIPTION
简单地调整了下设置与主题页面的首选项样式，统一将DropDownPreference修改为了与语言选择相同的ListPreference，原因在于DropDownPreference在部分机型上比较难看以及与语言选择Pref行为不一致。不过引入了一个轻量级的Dialog库，不知道你是否介意。
修改了下登录页面SystemUiVisibility，原因在于StatusBar Color设置为透明在部分机型上显示为完全透明（没有灰色遮罩）。
虽然代码不多，但可能还是会有考虑不周的地方，烦请指出，Thx。
